### PR TITLE
Fix typo in consumer service interface

### DIFF
--- a/Messaging/Interface/IConsumerService.cs
+++ b/Messaging/Interface/IConsumerService.cs
@@ -2,6 +2,6 @@
 {
     public interface IConsumerService
     {
-        Task ReadMessgaes();
+        Task ReadMessages();
     }
 }


### PR DESCRIPTION
## Summary
- rename `ReadMessgaes` to `ReadMessages` in `IConsumerService`

## Testing
- `dotnet build TechChallenge1.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fab6b95f48328abcdd50613d13d53